### PR TITLE
Feature: Configurable Host Setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,8 @@ class HttpdFacility extends Base {
     }
 
     return await this.server.listen({
-      port: this.opts.port || this.conf.port
+      port: this.opts.port || this.conf.port,
+      host: this.opts.host || this.conf.host
     })
   }
 


### PR DESCRIPTION
Previously the host settings were defaulting to 127.0.0.1 because of fastify default. Made it configurable to either take from otps first or take from conf otherwise default to what's currently it